### PR TITLE
Remove password restrictions when in DEBUG

### DIFF
--- a/naga/settings.py
+++ b/naga/settings.py
@@ -77,9 +77,9 @@ WSGI_APPLICATION = 'naga.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'testdb',
-        'USER': 'testdbuser',
-        'PASSWORD': 'password',
+        'NAME': 'ctf',
+        'USER': 'ctf',
+        'PASSWORD': 'ctf',
         'HOST': 'localhost',
         'PORT': '5432',
     }
@@ -89,20 +89,21 @@ DATABASES = {
 # Password validation
 # https://docs.djangoproject.com/en/1.10/ref/settings/#auth-password-validators
 
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
-]
+if DEBUG is False:
+    AUTH_PASSWORD_VALIDATORS = [
+        {
+            'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        },
+        {
+            'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        },
+        {
+            'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        },
+        {
+            'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        },
+    ]
 
 
 # Internationalization


### PR DESCRIPTION
Remove password restrictions while in DEBUG mode.  Need to come up with an agreed user/pass/database for testing/coding to avoid having to change constantly.  Shorter = better for DEBUGGING.